### PR TITLE
fixed: Hero section header hiding due to MessageBubble

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -34,7 +34,7 @@ export default function Hero() {
       </p>
       <MessageBubble
         message="You spend like money respawns 💸"
-        className="absolute top-30 rotate-10 hidden lg:block"
+        className="absolute top-20 -rotate-7 hidden lg:block"
       />
       <MessageBubble
         message="You treat money like it's a rumor, gone in seconds."
@@ -43,7 +43,7 @@ export default function Hero() {
 
       <MessageBubble
         message="Bank account: 0. Self-respect: also 0"
-        className="absolute top-30 right-0 rotate-10 hidden lg:block"
+        className="absolute top-20 right-0 rotate-10 hidden lg:block"
       />
 
       <MessageBubble


### PR DESCRIPTION
**Issue :**
>MessageBubble was hiding the Hero section header.
<img width="1619" height="521" alt="image" src="https://github.com/user-attachments/assets/af202d0b-a376-4f14-b057-1e547830abd9" />

---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
**Fixes:**

> Fixed MessageBubble by giving the rotation value as negative.

<img width="1907" height="1089" alt="image" src="https://github.com/user-attachments/assets/5352f7ff-0abb-4bd4-8488-8df856cf3a20" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined positioning and rotation of decorative message bubbles in the hero section for improved visual balance on large screens.
  * Adjusted spacing from top and right edges to create a cleaner, more polished layout.
  * Maintains existing visibility behavior across breakpoints (hidden on small screens, visible on large).
  * Cosmetic update only—no changes to functionality or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->